### PR TITLE
Sourcing openfoam before pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ cd modules/multiDimAMR/
 ```
 ### running testsuite
 
-assuming you have installed python version >= 3.6 (miniconda is a great option)
+make sure that the desired openfoam installation is sourced e.g. v1812 and that 
+python is installed with a version >= 3.6 (miniconda is a great option, but anaconda works as well)
 
 ```
 python -m venv env # creats virtual python enviroments (optional step)


### PR DESCRIPTION
Added a comment to make users aware to source openfoam before using ```py.test```
If not sourced properly the pytest comment produces numerous errors.